### PR TITLE
Improve recommendation relevance and limit control

### DIFF
--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -45,7 +45,10 @@ export async function POST(req: Request) {
       typeof payload.limit === "number"
         ? Math.min(Math.max(Math.trunc(payload.limit), 1), 50)
         : undefined;
-    const requestBody: RecommendRequestBody = { url: payload.url, limit };
+    const requestBody: RecommendRequestBody = { url: payload.url };
+    if (typeof limit === "number") {
+      requestBody.limit = limit;
+    }
 
     const serviceToken = process.env.RECOMMENDER_SERVICE_TOKEN;
     if (!serviceToken) {

--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -10,6 +10,7 @@ import type { SpotifyTokenResponse } from "@/lib/server-auth";
 
 interface RecommendRequestBody {
   url?: string;
+  limit?: number;
 }
 
 const DEFAULT_BACKEND_URL = "http://127.0.0.1:8000";
@@ -40,6 +41,12 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "missing_url" }, { status: 400 });
     }
 
+    const limit =
+      typeof payload.limit === "number"
+        ? Math.min(Math.max(Math.trunc(payload.limit), 1), 50)
+        : undefined;
+    const requestBody: RecommendRequestBody = { url: payload.url, limit };
+
     const serviceToken = process.env.RECOMMENDER_SERVICE_TOKEN;
     if (!serviceToken) {
       return NextResponse.json({ error: "misconfigured_service_token" }, { status: 500 });
@@ -54,7 +61,7 @@ export async function POST(req: Request) {
     const cookieStore = cookies();
     let accessToken = initialToken;
     let tokensToPersist: SpotifyTokenResponse | undefined = refreshedTokens;
-    let backendResponse = await callBackend(backendBase, serviceToken, accessToken, payload);
+    let backendResponse = await callBackend(backendBase, serviceToken, accessToken, requestBody);
 
     if (backendResponse.status === 401) {
       const refreshToken = tokensToPersist?.refresh_token || cookieStore.get("sp_refresh_token")?.value || null;
@@ -62,7 +69,7 @@ export async function POST(req: Request) {
         const newTokens = await refreshSpotifyTokens(refreshToken);
         tokensToPersist = newTokens;
         accessToken = newTokens.access_token;
-        backendResponse = await callBackend(backendBase, serviceToken, accessToken, payload);
+        backendResponse = await callBackend(backendBase, serviceToken, accessToken, requestBody);
       }
     }
 

--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -23,6 +23,7 @@ export function HomeClient({ signedIn }: { signedIn: boolean }) {
   const [profileLoading, setProfileLoading] = useState(false);
 
   const [inputUrl, setInputUrl] = useState("");
+  const [limit, setLimit] = useState(15);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<RecommendationResponse | null>(null);
@@ -66,7 +67,7 @@ export function HomeClient({ signedIn }: { signedIn: boolean }) {
     try {
       setLoading(true);
       setError(null);
-      const data = await requestRecommendations(inputUrl.trim());
+      const data = await requestRecommendations(inputUrl.trim(), limit);
       setResult(data);
       setHistory((prev) => [data, ...prev].slice(0, MAX_HISTORY));
     } catch (err: unknown) {
@@ -134,6 +135,22 @@ export function HomeClient({ signedIn }: { signedIn: boolean }) {
             value={inputUrl}
             onChange={(event) => setInputUrl(event.target.value)}
             required
+            disabled={loading}
+          />
+          <label htmlFor="limit">How many recommendations?</label>
+          <input
+            id="limit"
+            type="number"
+            min={1}
+            max={50}
+            value={limit}
+            onChange={(event) => {
+              const parsed = Number(event.target.value);
+              if (!Number.isNaN(parsed)) {
+                const clamped = Math.min(Math.max(Math.trunc(parsed), 1), 50);
+                setLimit(clamped);
+              }
+            }}
             disabled={loading}
           />
           <button className="cta" type="submit" disabled={loading}>

--- a/backend/app/api/routes/recommend.py
+++ b/backend/app/api/routes/recommend.py
@@ -34,6 +34,9 @@ async def create_recommendations(
 ) -> RecommendResponse:
     entity = parse_spotify_url(payload.url)
     try:
+        limit = payload.limit or settings.recommendation_top_k
+        limit = max(1, min(limit, settings.recommendation_max_limit))
+
         response = await recommend_for_entity(
             entity,
             session=session,
@@ -41,6 +44,7 @@ async def create_recommendations(
             spotify_client=spotify_client,
             index_service=index_service,
             settings=settings,
+            limit=limit,
         )
         return response
     except SpotifyAuthError as exc:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     faiss_meta_path: Path = Path("/data/index.json")
     dsp_preview_timeout: int = 12
     recommendation_top_k: int = 15
+    recommendation_max_limit: int = 50
     playlist_ingest_batch_size: int = 75
     http_timeout_seconds: float = 15.0
     http_retries: int = 3

--- a/backend/app/schemas/recommend.py
+++ b/backend/app/schemas/recommend.py
@@ -9,6 +9,12 @@ from ..spotify.parsing import parse_spotify_url
 
 class RecommendRequest(BaseModel):
     url: str = Field(..., description="Spotify track or playlist URL/URI")
+    limit: int | None = Field(
+        None,
+        ge=1,
+        le=50,
+        description="Desired number of recommendations to return",
+    )
 
     @field_validator("url")
     @classmethod

--- a/backend/app/spotify/client.py
+++ b/backend/app/spotify/client.py
@@ -194,6 +194,7 @@ class SpotifyClient:
         seed_artists: Sequence[str] | None = None,
         seed_genres: Sequence[str] | None = None,
         limit: int = 20,
+        tunable_params: Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
         params: Dict[str, Any] = {"limit": max(1, min(limit, 100))}
         if seed_tracks:
@@ -202,6 +203,8 @@ class SpotifyClient:
             params["seed_artists"] = ",".join(list(dict.fromkeys([artist for artist in seed_artists if artist])))
         if seed_genres:
             params["seed_genres"] = ",".join(list(dict.fromkeys([genre for genre in seed_genres if genre])))
+        if tunable_params:
+            params.update({key: value for key, value in tunable_params.items() if value is not None})
         return await self._request("GET", "/recommendations", params=params)
 
     async def get_playlist(self, playlist_id: str) -> Dict[str, Any]:

--- a/backend/app/spotify/client.py
+++ b/backend/app/spotify/client.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, Iterable, List
+from typing import Any, AsyncIterator, Dict, Iterable, List, Sequence
 
 import httpx
 
@@ -186,6 +186,23 @@ class SpotifyClient:
 
     async def get_audio_analysis(self, track_id: str) -> Dict[str, Any]:
         return await self._request("GET", f"/audio-analysis/{track_id}")
+
+    async def get_recommendations(
+        self,
+        *,
+        seed_tracks: Sequence[str] | None = None,
+        seed_artists: Sequence[str] | None = None,
+        seed_genres: Sequence[str] | None = None,
+        limit: int = 20,
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"limit": max(1, min(limit, 100))}
+        if seed_tracks:
+            params["seed_tracks"] = ",".join(list(dict.fromkeys([track for track in seed_tracks if track])))
+        if seed_artists:
+            params["seed_artists"] = ",".join(list(dict.fromkeys([artist for artist in seed_artists if artist])))
+        if seed_genres:
+            params["seed_genres"] = ",".join(list(dict.fromkeys([genre for genre in seed_genres if genre])))
+        return await self._request("GET", "/recommendations", params=params)
 
     async def get_playlist(self, playlist_id: str) -> Dict[str, Any]:
         params = {

--- a/backend/tests/test_recommendations.py
+++ b/backend/tests/test_recommendations.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence
+
+import numpy as np
+import pytest
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.core.config import Settings
+from app.db import models
+from app.db.base import Base
+from app.services.recommendations import (
+    _backfill_with_spotify,
+    _ensure_track_vector,
+    _load_track_with_artists,
+)
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_to_sqlite(element, compiler, **kw):  # pragma: no cover - SQLite shim
+    return "JSON"
+
+
+class _StubIndexService:
+    def __init__(self) -> None:
+        self.vectors: Dict[str, np.ndarray] = {}
+
+    async def ensure_loaded(self, session) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+    async def add_vectors(self, items: Iterable[tuple[str, np.ndarray]]) -> None:
+        for track_id, vector in items:
+            self.vectors[track_id] = vector
+
+    async def search(self, vector: np.ndarray, *, top_k: int) -> List[tuple[str, float]]:  # pragma: no cover - unused here
+        return []
+
+
+@dataclass(slots=True)
+class _StubSpotifyClient:
+    tracks: Dict[str, Dict[str, Any]]
+    features: Dict[str, Dict[str, Any]]
+    analysis: Dict[str, Dict[str, Any]]
+    artists: Dict[str, Dict[str, Any]]
+    recommendations: List[Dict[str, Any]]
+
+    async def get_track(self, track_id: str) -> Dict[str, Any]:
+        return self.tracks[track_id]
+
+    async def get_audio_features(self, track_id: str) -> Dict[str, Any]:
+        return self.features[track_id]
+
+    async def get_audio_analysis(self, track_id: str) -> Dict[str, Any]:
+        return self.analysis[track_id]
+
+    async def get_artists(self, artist_ids: Iterable[str]) -> List[Dict[str, Any]]:
+        return [self.artists[artist_id] for artist_id in artist_ids if artist_id in self.artists]
+
+    async def get_recommendations(
+        self,
+        *,
+        seed_tracks: Sequence[str] | None = None,
+        seed_artists: Sequence[str] | None = None,
+        seed_genres: Sequence[str] | None = None,
+        limit: int = 20,
+    ) -> Dict[str, Any]:  # pragma: no cover - parameters unused in stub
+        return {"tracks": list(self.recommendations)}
+
+
+async def _run_backfill_flow(tmp_path: Path) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with maker() as session:
+        seed_track_id = "seed-track"
+        recommendation_id = "rec-track"
+
+        seed_artist_id = "seed-artist"
+        rec_artist_id = "rec-artist"
+
+        stub_client = _StubSpotifyClient(
+            tracks={
+                seed_track_id: {
+                    "id": seed_track_id,
+                    "name": "Seed Song",
+                    "duration_ms": 180000,
+                    "explicit": False,
+                    "popularity": 40,
+                    "preview_url": None,
+                    "uri": "spotify:track:seed",
+                    "external_urls": {"spotify": "https://open.spotify.com/track/seed"},
+                    "album": {
+                        "id": "seed-album",
+                        "name": "Seed Album",
+                        "images": [{"url": "https://example.com/seed.jpg"}],
+                    },
+                    "artists": [
+                        {
+                            "id": seed_artist_id,
+                            "name": "Seed Artist",
+                        }
+                    ],
+                }
+            },
+            features={
+                seed_track_id: {
+                    "id": seed_track_id,
+                    "danceability": 0.62,
+                    "energy": 0.41,
+                    "speechiness": 0.05,
+                    "acousticness": 0.6,
+                    "instrumentalness": 0.0,
+                    "liveness": 0.12,
+                    "valence": 0.34,
+                    "tempo": 96.0,
+                    "mode": 1,
+                    "key": 5,
+                    "loudness": -8.0,
+                    "duration_ms": 180000,
+                },
+                recommendation_id: {
+                    "id": recommendation_id,
+                    "danceability": 0.64,
+                    "energy": 0.39,
+                    "speechiness": 0.04,
+                    "acousticness": 0.58,
+                    "instrumentalness": 0.0,
+                    "liveness": 0.15,
+                    "valence": 0.36,
+                    "tempo": 95.0,
+                    "mode": 1,
+                    "key": 5,
+                    "loudness": -9.0,
+                    "duration_ms": 182000,
+                },
+            },
+            analysis={
+                seed_track_id: {
+                    "track": {
+                        "tempo_confidence": 0.8,
+                        "time_signature": 4,
+                        "time_signature_confidence": 0.7,
+                        "key_confidence": 0.5,
+                    },
+                    "sections": [],
+                },
+                recommendation_id: {
+                    "track": {
+                        "tempo_confidence": 0.82,
+                        "time_signature": 4,
+                        "time_signature_confidence": 0.68,
+                        "key_confidence": 0.45,
+                    },
+                    "sections": [],
+                },
+            },
+            artists={
+                seed_artist_id: {
+                    "id": seed_artist_id,
+                    "name": "Seed Artist",
+                    "genres": ["viet r&b"],
+                },
+                rec_artist_id: {
+                    "id": rec_artist_id,
+                    "name": "Rec Artist",
+                    "genres": ["viet r&b", "asian r&b"],
+                },
+            },
+            recommendations=[
+                {
+                    "id": recommendation_id,
+                    "name": "Recommended Song",
+                    "duration_ms": 182000,
+                    "explicit": False,
+                    "popularity": 45,
+                    "preview_url": None,
+                    "uri": "spotify:track:rec",
+                    "external_urls": {"spotify": "https://open.spotify.com/track/rec"},
+                    "album": {
+                        "id": "rec-album",
+                        "name": "Rec Album",
+                        "images": [{"url": "https://example.com/rec.jpg"}],
+                    },
+                    "artists": [
+                        {
+                            "id": rec_artist_id,
+                            "name": "Rec Artist",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        settings = Settings(
+            faiss_index_path=tmp_path / "index.faiss",
+            faiss_meta_path=tmp_path / "index.json",
+            dsp_preview_timeout=0,
+        )
+        index_service = _StubIndexService()
+
+        seed_track, seed_vector, seed_features, _ = await _ensure_track_vector(
+            session,
+            stub_client,
+            index_service,
+            settings,
+            track_payload=await stub_client.get_track(seed_track_id),
+        )
+
+        seed_track_loaded = await _load_track_with_artists(session, seed_track.id)
+        assert seed_track_loaded is not None
+
+        recommendations = await _backfill_with_spotify(
+            session,
+            stub_client,
+            index_service,
+            settings,
+            seed_track=seed_track_loaded,
+            seed_vector=seed_vector,
+            seed_features=seed_features,
+            seed_genres={"viet r&b"},
+            existing=[],
+            limit=3,
+        )
+
+        assert any(item.track_id == recommendation_id for item in recommendations)
+
+        ingested_track = await session.get(models.Track, recommendation_id)
+        assert ingested_track is not None
+        assert {artist.id for artist in ingested_track.artists} == {rec_artist_id}
+
+    await engine.dispose()
+
+
+def test_spotify_backfill_ingests_unseen_tracks(tmp_path: Path) -> None:
+    asyncio.run(_run_backfill_flow(tmp_path))

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -49,11 +49,15 @@ export type SpotifyProfile = {
   email?: string;
 };
 
-export async function requestRecommendations(url: string): Promise<RecommendationResponse> {
+export async function requestRecommendations(url: string, limit?: number): Promise<RecommendationResponse> {
+  const payload: { url: string; limit?: number } = { url };
+  if (typeof limit === "number") {
+    payload.limit = limit;
+  }
   const res = await fetch("/api/recommend", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url }),
+    body: JSON.stringify(payload),
   });
   const data = await res.json();
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- allow clients to request a configurable number of recommendations end-to-end
- add a limit selector to the dashboard UI and forward the new parameter to the backend
- tune the ranking logic to prioritize genre matches and clamp limits against configuration values

## Testing
- npm run lint
- cd backend && pytest


------
https://chatgpt.com/codex/tasks/task_e_68db2714e9208320adf82ec91de0a351