### PR TITLE
Switch recommendations to Spotify-sourced results

### DIFF
--- a/app/components/HomeClient.tsx
+++ b/app/components/HomeClient.tsx
@@ -23,6 +23,7 @@ export function HomeClient({ signedIn }: { signedIn: boolean }) {
   const [profileLoading, setProfileLoading] = useState(false);
 
   const [inputUrl, setInputUrl] = useState("");
+  const [limit, setLimit] = useState(15);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<RecommendationResponse | null>(null);
@@ -66,7 +67,7 @@ export function HomeClient({ signedIn }: { signedIn: boolean }) {
     try {
       setLoading(true);
       setError(null);
-      const data = await requestRecommendations(inputUrl.trim());
+      const data = await requestRecommendations(inputUrl.trim(), limit);
       setResult(data);
       setHistory((prev) => [data, ...prev].slice(0, MAX_HISTORY));
     } catch (err: unknown) {
@@ -134,6 +135,22 @@ export function HomeClient({ signedIn }: { signedIn: boolean }) {
             value={inputUrl}
             onChange={(event) => setInputUrl(event.target.value)}
             required
+            disabled={loading}
+          />
+          <label htmlFor="limit">How many recommendations?</label>
+          <input
+            id="limit"
+            type="number"
+            min={1}
+            max={50}
+            value={limit}
+            onChange={(event) => {
+              const parsed = Number(event.target.value);
+              if (!Number.isNaN(parsed)) {
+                const clamped = Math.min(Math.max(Math.trunc(parsed), 1), 50);
+                setLimit(clamped);
+              }
+            }}
             disabled={loading}
           />
           <button className="cta" type="submit" disabled={loading}>

--- a/backend/app/api/routes/recommend.py
+++ b/backend/app/api/routes/recommend.py
@@ -34,6 +34,9 @@ async def create_recommendations(
 ) -> RecommendResponse:
     entity = parse_spotify_url(payload.url)
     try:
+        limit = payload.limit or settings.recommendation_top_k
+        limit = max(1, min(limit, settings.recommendation_max_limit))
+
         response = await recommend_for_entity(
             entity,
             session=session,
@@ -41,6 +44,7 @@ async def create_recommendations(
             spotify_client=spotify_client,
             index_service=index_service,
             settings=settings,
+            limit=limit,
         )
         return response
     except SpotifyAuthError as exc:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     faiss_meta_path: Path = Path("/data/index.json")
     dsp_preview_timeout: int = 12
     recommendation_top_k: int = 15
+    recommendation_max_limit: int = 50
     playlist_ingest_batch_size: int = 75
     http_timeout_seconds: float = 15.0
     http_retries: int = 3

--- a/backend/app/schemas/recommend.py
+++ b/backend/app/schemas/recommend.py
@@ -9,6 +9,12 @@ from ..spotify.parsing import parse_spotify_url
 
 class RecommendRequest(BaseModel):
     url: str = Field(..., description="Spotify track or playlist URL/URI")
+    limit: int | None = Field(
+        None,
+        ge=1,
+        le=50,
+        description="Desired number of recommendations to return",
+    )
 
     @field_validator("url")
     @classmethod

--- a/backend/app/services/recommendations.py
+++ b/backend/app/services/recommendations.py
@@ -38,6 +38,33 @@ AUDIO_FEATURE_KEYS = [
     "mode",
 ]
 
+RECOMMENDATION_FLOAT_CONSTRAINTS: Dict[str, Tuple[float, float, float]] = {
+    "danceability": (0.0, 1.0, 0.12),
+    "energy": (0.0, 1.0, 0.15),
+    "valence": (0.0, 1.0, 0.15),
+    "acousticness": (0.0, 1.0, 0.2),
+    "instrumentalness": (0.0, 1.0, 0.2),
+    "liveness": (0.0, 1.0, 0.18),
+    "speechiness": (0.0, 1.0, 0.1),
+}
+
+TEMPO_RANGE = (30.0, 220.0, 8.0)
+LOUDNESS_RANGE = (-60.0, 0.0, 5.0)
+DURATION_RANGE = (30000.0, 600000.0, 20000.0)
+
+FEATURE_ALIGNMENT_RULES: Sequence[Tuple[str, float, float]] = (
+    ("danceability", 0.18, 1.0),
+    ("energy", 0.22, 1.0),
+    ("valence", 0.22, 0.95),
+    ("acousticness", 0.28, 0.7),
+    ("instrumentalness", 0.3, 0.55),
+    ("speechiness", 0.18, 0.4),
+)
+TEMPO_ALIGNMENT_TOLERANCE = 18.0
+LOUDNESS_ALIGNMENT_TOLERANCE = 6.0
+DURATION_ALIGNMENT_TOLERANCE = 60000.0
+MIN_ALIGNMENT_SCORE = 0.38
+
 SharedGenres = Set[str]
 
 
@@ -265,10 +292,155 @@ def _collect_genres(artists: Sequence[models.Artist]) -> SharedGenres:
     return genres
 
 
-def _compute_similarity_score(raw_score: float, genre_overlap: int) -> float:
+def _coerce_float(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_spotify_tunable_params(
+    seed_features: Dict[str, Any],
+    *,
+    seed_track: models.Track | None = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {}
+
+    for field, (lower, upper, window) in RECOMMENDATION_FLOAT_CONSTRAINTS.items():
+        numeric = _coerce_float(seed_features.get(field))
+        if numeric is None:
+            continue
+        clamped = max(lower, min(numeric, upper))
+        params[f"target_{field}"] = round(clamped, 3)
+        params[f"min_{field}"] = round(max(lower, clamped - window), 3)
+        params[f"max_{field}"] = round(min(upper, clamped + window), 3)
+
+    tempo = _coerce_float(seed_features.get("tempo"))
+    if tempo is not None:
+        tempo_min, tempo_max, tempo_window = TEMPO_RANGE
+        tempo_clamped = max(tempo_min, min(tempo, tempo_max))
+        params["target_tempo"] = round(tempo_clamped, 2)
+        params["min_tempo"] = round(max(tempo_min, tempo_clamped - tempo_window), 2)
+        params["max_tempo"] = round(min(tempo_max, tempo_clamped + tempo_window), 2)
+
+    duration = _coerce_float(seed_features.get("duration_ms"))
+    if duration is None and seed_track and seed_track.duration_ms is not None:
+        duration = float(seed_track.duration_ms)
+    if duration is not None:
+        duration_min, duration_max, duration_window = DURATION_RANGE
+        dynamic_window = max(duration_window, duration * 0.15)
+        duration_clamped = max(duration_min, min(duration, duration_max))
+        params["target_duration_ms"] = int(round(duration_clamped))
+        params["min_duration_ms"] = int(max(duration_min, duration_clamped - dynamic_window))
+        params["max_duration_ms"] = int(min(duration_max, duration_clamped + dynamic_window))
+
+    loudness = _coerce_float(seed_features.get("loudness"))
+    if loudness is not None:
+        loud_min, loud_max, loud_window = LOUDNESS_RANGE
+        loud_clamped = max(loud_min, min(loudness, loud_max))
+        params["target_loudness"] = round(loud_clamped, 2)
+        params["min_loudness"] = round(max(loud_min, loud_clamped - loud_window), 2)
+        params["max_loudness"] = round(min(loud_max, loud_clamped + loud_window), 2)
+
+    mode = seed_features.get("mode")
+    if isinstance(mode, (int, float)):
+        params["target_mode"] = 1 if int(round(mode)) else 0
+
+    key = seed_features.get("key")
+    if isinstance(key, (int, float)):
+        key_int = int(round(key)) % 12
+        params["target_key"] = key_int
+
+    popularity = getattr(seed_track, "popularity", None)
+    if popularity is not None:
+        popularity_int = int(popularity)
+        params["min_popularity"] = max(0, popularity_int - 15)
+        params["max_popularity"] = min(100, popularity_int + 15)
+
+    return params
+
+
+def _compute_feature_alignment(
+    seed_features: Dict[str, Any],
+    candidate_features: Dict[str, Any],
+) -> float:
+    score = 0.0
+    total_weight = 0.0
+
+    for field, tolerance, weight in FEATURE_ALIGNMENT_RULES:
+        seed_value = _coerce_float(seed_features.get(field))
+        candidate_value = _coerce_float(candidate_features.get(field))
+        if seed_value is None or candidate_value is None:
+            continue
+        diff = abs(seed_value - candidate_value)
+        closeness = max(0.0, 1.0 - min(diff / tolerance, 1.0))
+        score += closeness * weight
+        total_weight += weight
+
+    tempo_seed = _coerce_float(seed_features.get("tempo"))
+    tempo_candidate = _coerce_float(candidate_features.get("tempo"))
+    if tempo_seed is not None and tempo_candidate is not None:
+        tempo_diff = abs(tempo_seed - tempo_candidate)
+        closeness = max(0.0, 1.0 - min(tempo_diff / TEMPO_ALIGNMENT_TOLERANCE, 1.0))
+        score += closeness * 1.1
+        total_weight += 1.1
+
+    loudness_seed = _coerce_float(seed_features.get("loudness"))
+    loudness_candidate = _coerce_float(candidate_features.get("loudness"))
+    if loudness_seed is not None and loudness_candidate is not None:
+        loudness_diff = abs(loudness_seed - loudness_candidate)
+        closeness = max(0.0, 1.0 - min(loudness_diff / LOUDNESS_ALIGNMENT_TOLERANCE, 1.0))
+        score += closeness * 0.6
+        total_weight += 0.6
+
+    duration_seed = _coerce_float(seed_features.get("duration_ms"))
+    duration_candidate = _coerce_float(candidate_features.get("duration_ms"))
+    if duration_seed is not None and duration_candidate is not None:
+        duration_diff = abs(duration_seed - duration_candidate)
+        closeness = max(0.0, 1.0 - min(duration_diff / DURATION_ALIGNMENT_TOLERANCE, 1.0))
+        score += closeness * 0.6
+        total_weight += 0.6
+
+    mode_seed = _coerce_float(seed_features.get("mode"))
+    mode_candidate = _coerce_float(candidate_features.get("mode"))
+    if mode_seed is not None and mode_candidate is not None:
+        same_mode = 1.0 if int(round(mode_seed)) == int(round(mode_candidate)) else 0.0
+        score += same_mode * 0.3
+        total_weight += 0.3
+
+    key_seed = _coerce_float(seed_features.get("key"))
+    key_candidate = _coerce_float(candidate_features.get("key"))
+    if key_seed is not None and key_candidate is not None:
+        seed_int = int(round(key_seed)) % 12
+        candidate_int = int(round(key_candidate)) % 12
+        distance = abs(seed_int - candidate_int)
+        distance = min(distance, 12 - distance)
+        closeness = max(0.0, 1.0 - min(distance / 4.0, 1.0))
+        score += closeness * 0.4
+        total_weight += 0.4
+
+    if total_weight == 0.0:
+        return 0.5
+    return max(min(score / total_weight, 1.0), 0.0)
+
+
+def _compute_similarity_score(
+    raw_score: float,
+    genre_overlap: int,
+    seed_genre_count: int,
+    feature_alignment: float,
+) -> float:
     base = max(min((raw_score + 1.0) / 2.0, 1.0), 0.0)
-    boost = min(genre_overlap * 0.04, 0.12)
-    return max(min(base + boost, 1.0), 0.0)
+    combined = (base * 0.6) + (feature_alignment * 0.4)
+    if seed_genre_count > 0:
+        if genre_overlap > 0:
+            boost = 0.07 + max(genre_overlap - 1, 0) * 0.035
+            combined += min(boost, 0.2)
+        else:
+            combined -= 0.24
+    elif genre_overlap > 0:
+        combined += min(genre_overlap * 0.03, 0.09)
+    return max(min(combined, 1.0), 0.0)
 
 
 def _build_explanation(
@@ -305,6 +477,15 @@ def _build_explanation(
     if len(highlights) == 1:
         return highlights[0].capitalize()
     return highlights[0].capitalize() + "; " + "; ".join(highlights[1:])
+
+
+def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    if a.size == 0 or b.size == 0:
+        return 0.0
+    denom = float(np.linalg.norm(a) * np.linalg.norm(b))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(a, b) / denom)
 
 
 def _average_audio_features(features_list: Sequence[Dict[str, Any]]) -> Dict[str, float]:
@@ -441,7 +622,8 @@ async def _hydrate_recommendations(
         row[0].id: (row[0], row[1]) for row in result.all()
     }
 
-    ranked: List[Tuple[float, models.Track, models.TrackFeature, SharedGenres]] = []
+    seed_genre_count = len(seed_genres)
+    ranked: List[Tuple[float, float, models.Track, models.TrackFeature, SharedGenres, int]] = []
     for track_id, raw_score in matches:
         if track_id in exclude:
             continue
@@ -451,14 +633,19 @@ async def _hydrate_recommendations(
         track_obj, feature_obj = data
         candidate_genres = _collect_genres(track_obj.artists)
         genre_overlap = len(seed_genres & candidate_genres)
-        similarity = _compute_similarity_score(raw_score, genre_overlap)
-        ranked.append((similarity, track_obj, feature_obj, candidate_genres))
+        alignment = _compute_feature_alignment(seed_features, feature_obj.audio_features)
+        if alignment < MIN_ALIGNMENT_SCORE and genre_overlap == 0:
+            continue
+        similarity = _compute_similarity_score(raw_score, genre_overlap, seed_genre_count, alignment)
+        if similarity < MIN_ALIGNMENT_SCORE:
+            continue
+        ranked.append((similarity, alignment, track_obj, feature_obj, candidate_genres, genre_overlap))
 
-    ranked.sort(key=lambda item: item[0], reverse=True)
+    ranked.sort(key=lambda item: (item[5] > 0, item[0], item[1]), reverse=True)
 
     final: List[RecommendationItem] = []
     seen_artists: Set[str] = set()
-    for similarity, track_obj, feature_obj, candidate_genres in ranked:
+    for similarity, _, track_obj, feature_obj, candidate_genres, _ in ranked:
         if len(final) >= top_k:
             break
         artist_ids = {artist.id for artist in track_obj.artists}
@@ -470,6 +657,141 @@ async def _hydrate_recommendations(
     return final
 
 
+async def _collect_seen_artist_ids(session: AsyncSession, track_ids: Set[str]) -> Set[str]:
+    if not track_ids:
+        return set()
+    result = await session.execute(
+        select(models.Track)
+        .options(selectinload(models.Track.artists))
+        .where(models.Track.id.in_(track_ids))
+    )
+    seen: Set[str] = set()
+    for track in result.scalars():
+        seen.update(artist.id for artist in track.artists if artist.id)
+    return seen
+
+
+async def _backfill_with_spotify(
+    session: AsyncSession,
+    spotify_client: SpotifyClient,
+    index_service: FaissService,
+    settings: Settings,
+    *,
+    seed_track: models.Track,
+    seed_vector: np.ndarray,
+    seed_features: Dict[str, Any],
+    seed_genres: SharedGenres,
+    existing: List[RecommendationItem],
+    limit: int,
+    additional_exclude: Optional[Set[str]] = None,
+    extra_seed_tracks: Sequence[str] | None = None,
+    extra_seed_artists: Sequence[str] | None = None,
+) -> List[RecommendationItem]:
+    needed = limit - len(existing)
+    if needed <= 0:
+        return existing
+
+    existing_ids = {item.track_id for item in existing}
+    exclude_ids = existing_ids | {seed_track.id}
+    if additional_exclude:
+        exclude_ids |= set(additional_exclude)
+    seen_artists = await _collect_seen_artist_ids(session, existing_ids)
+
+    artist_ids = [artist.id for artist in seed_track.artists if artist.id]
+    if extra_seed_artists:
+        for artist_id in extra_seed_artists:
+            if artist_id and artist_id not in artist_ids:
+                artist_ids.append(artist_id)
+    seed_genre_list = sorted(seed_genres)
+    tunable_params = _build_spotify_tunable_params(seed_features, seed_track=seed_track)
+
+    try:
+        rec_payload = await spotify_client.get_recommendations(
+            seed_tracks=[seed_track.id] + list((extra_seed_tracks or [])[:4]),
+            seed_artists=artist_ids[:5],
+            seed_genres=seed_genre_list[:2],
+            limit=min(max(needed * 2, needed + 2), settings.recommendation_max_limit * 2),
+            tunable_params=tunable_params,
+        )
+    except SpotifyClientError as exc:
+        logger.warning("Spotify fallback recommendations failed for %s: %s", seed_track.id, exc)
+        return existing
+
+    tracks_payload = rec_payload.get("tracks") if isinstance(rec_payload, dict) else None
+    if not tracks_payload:
+        return existing
+
+    seed_genre_count = len(seed_genres)
+    augmented: List[Tuple[int, float, RecommendationItem, Set[str]]] = []
+    for track_payload in tracks_payload:
+        track_id = track_payload.get("id") if isinstance(track_payload, dict) else None
+        if not track_id or track_id in exclude_ids:
+            continue
+        try:
+            candidate_track, candidate_vector, candidate_features, _ = await _ensure_track_vector(
+                session,
+                spotify_client,
+                index_service,
+                settings,
+                track_payload=track_payload,
+            )
+        except SpotifyClientError as exc:
+            logger.debug("Failed to ingest recommended track %s: %s", track_id, exc)
+            continue
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Unexpected error ingesting recommended track %s: %s", track_id, exc)
+            continue
+
+        track_with_relations = await _load_track_with_artists(session, candidate_track.id)
+        if track_with_relations is not None:
+            candidate_track = track_with_relations
+
+        candidate_genres = _collect_genres(candidate_track.artists)
+        raw_score = _cosine_similarity(seed_vector, candidate_vector)
+        genre_overlap = len(seed_genres & candidate_genres)
+        alignment = _compute_feature_alignment(seed_features, candidate_features)
+        if alignment < MIN_ALIGNMENT_SCORE and genre_overlap == 0:
+            continue
+        similarity = _compute_similarity_score(
+            raw_score,
+            genre_overlap,
+            seed_genre_count,
+            alignment,
+        )
+        if similarity < MIN_ALIGNMENT_SCORE:
+            continue
+        shared = seed_genres & candidate_genres
+        explanation = _build_explanation(seed_features, candidate_features, shared)
+
+        artist_ids_set = {artist.id for artist in candidate_track.artists if artist.id}
+        penalty = 0.08 if seen_artists & artist_ids_set else 0.0
+        adjusted = max(similarity - penalty, 0.0)
+
+        if seed_genres and genre_overlap == 0 and adjusted < 0.65:
+            # Skip obviously unrelated tracks when we know the seed genres
+            continue
+
+        item = _track_to_recommendation(candidate_track, adjusted, explanation)
+        augmented.append((genre_overlap, alignment, adjusted, item, artist_ids_set))
+
+    if not augmented:
+        return existing
+
+    augmented.sort(key=lambda entry: (entry[0] > 0, entry[0], entry[1], entry[2]), reverse=True)
+
+    final = list(existing)
+    for genre_overlap, _, adjusted, item, artist_ids_set in augmented:
+        if len(final) >= limit:
+            break
+        if item.track_id in exclude_ids:
+            continue
+        final.append(item)
+        exclude_ids.add(item.track_id)
+        seen_artists.update(artist_ids_set)
+
+    return final
+
+
 async def _process_playlist(
     playlist_id: str,
     *,
@@ -478,6 +800,7 @@ async def _process_playlist(
     spotify_client: SpotifyClient,
     index_service: FaissService,
     settings: Settings,
+    top_k: int,
 ) -> RecommendResponse:
     lock_key = f"playlist:{playlist_id}:ingest"
     lock_acquired = await redis.set(lock_key, "1", nx=True, ex=600)
@@ -524,8 +847,12 @@ async def _process_playlist(
         vectors: List[np.ndarray] = []
         feature_payloads: List[Dict[str, Any]] = []
         seed_genres_counter: Counter[str] = Counter()
+        artist_counter: Counter[str] = Counter()
         track_objects: Dict[str, models.Track] = {}
         new_vectors: List[Tuple[str, np.ndarray]] = []
+        primary_track: Optional[models.Track] = None
+        primary_vector: Optional[np.ndarray] = None
+        primary_features: Optional[Dict[str, Any]] = None
 
         for _, track_payload in items:
             track_id = track_payload.get("id")
@@ -542,9 +869,14 @@ async def _process_playlist(
             vectors.append(vector)
             feature_payloads.append(features)
             seed_genres_counter.update(_collect_genres(track_obj.artists))
+            artist_counter.update([artist.id for artist in track_obj.artists if artist.id])
             track_objects[track_obj.id] = track_obj
             if updated:
                 new_vectors.append((track_obj.id, vector))
+            if primary_track is None:
+                primary_track = track_obj
+                primary_vector = vector
+                primary_features = features
 
         await session.execute(delete(models.PlaylistTrack).where(models.PlaylistTrack.playlist_id == playlist_id))
         for position, track_payload in items:
@@ -570,20 +902,30 @@ async def _process_playlist(
                 centroid = (centroid / norm).astype(np.float32)
 
         recommendations: List[RecommendationItem] = []
-        if centroid is not None:
-            await index_service.ensure_loaded(session)
-            matches = await index_service.search(centroid, top_k=settings.recommendation_top_k * 4)
-            exclude = set(track_ids)
-            seed_genres = set(genre for genre, _ in seed_genres_counter.most_common(20))
-            seed_features = _average_audio_features(feature_payloads)
-            recommendations = await _hydrate_recommendations(
-                session,
-                matches,
-                exclude=exclude,
-                seed_features=seed_features,
-                seed_genres=seed_genres,
-                top_k=settings.recommendation_top_k,
-            )
+        seed_features_avg = _average_audio_features(feature_payloads)
+        seed_genres = set(genre for genre, _ in seed_genres_counter.most_common(20))
+
+        if primary_track is not None and (centroid is not None or primary_vector is not None):
+            seed_vector = centroid if centroid is not None else primary_vector
+            if seed_vector is not None:
+                seed_features_payload = seed_features_avg or dict(primary_features or {})
+                extra_track_seeds = [tid for tid in track_ids if tid and tid != primary_track.id][:4]
+                extra_artist_seeds = [artist_id for artist_id, _ in artist_counter.most_common(4) if artist_id]
+                recommendations = await _backfill_with_spotify(
+                    session,
+                    spotify_client,
+                    index_service,
+                    settings,
+                    seed_track=primary_track,
+                    seed_vector=seed_vector,
+                    seed_features=seed_features_payload,
+                    seed_genres=seed_genres,
+                    existing=[],
+                    limit=top_k,
+                    additional_exclude=set(track_ids),
+                    extra_seed_tracks=extra_track_seeds,
+                    extra_seed_artists=extra_artist_seeds,
+                )
 
         summary = PlaylistIngestSummary(
             id=playlist.id,
@@ -619,6 +961,7 @@ async def recommend_for_entity(
     spotify_client: SpotifyClient,
     index_service: FaissService,
     settings: Settings,
+    limit: int,
 ) -> RecommendResponse:
     await index_service.ensure_loaded(session)
 
@@ -636,15 +979,18 @@ async def recommend_for_entity(
         if track_with_relations is not None:
             track = track_with_relations
 
-        matches = await index_service.search(vector, top_k=settings.recommendation_top_k * 3)
         seed_genres = _collect_genres(track.artists)
-        recommendations = await _hydrate_recommendations(
+        recommendations = await _backfill_with_spotify(
             session,
-            matches,
-            exclude={track.id},
+            spotify_client,
+            index_service,
+            settings,
+            seed_track=track,
+            seed_vector=vector,
             seed_features=features,
             seed_genres=seed_genres,
-            top_k=settings.recommendation_top_k,
+            existing=[],
+            limit=limit,
         )
         response = RecommendResponse(
             type="track",
@@ -662,6 +1008,7 @@ async def recommend_for_entity(
             spotify_client=spotify_client,
             index_service=index_service,
             settings=settings,
+            top_k=limit,
         )
 
     raise ValueError(f"Unsupported entity type {entity.kind}")

--- a/backend/app/spotify/client.py
+++ b/backend/app/spotify/client.py
@@ -172,6 +172,11 @@ class SpotifyClient:
             artists.extend(data.get("artists", []))
         return artists
 
+    async def get_related_artists(self, artist_id: str) -> Dict[str, Any]:
+        if not artist_id:
+            return {"artists": []}
+        return await self._request("GET", f"/artists/{artist_id}/related-artists")
+
     async def get_audio_features(self, track_id: str) -> Dict[str, Any]:
         return await self._request("GET", f"/audio-features/{track_id}")
 

--- a/backend/app/spotify/client.py
+++ b/backend/app/spotify/client.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, Iterable, List
+from typing import Any, AsyncIterator, Dict, Iterable, List, Sequence
 
 import httpx
 
@@ -186,6 +186,26 @@ class SpotifyClient:
 
     async def get_audio_analysis(self, track_id: str) -> Dict[str, Any]:
         return await self._request("GET", f"/audio-analysis/{track_id}")
+
+    async def get_recommendations(
+        self,
+        *,
+        seed_tracks: Sequence[str] | None = None,
+        seed_artists: Sequence[str] | None = None,
+        seed_genres: Sequence[str] | None = None,
+        limit: int = 20,
+        tunable_params: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"limit": max(1, min(limit, 100))}
+        if seed_tracks:
+            params["seed_tracks"] = ",".join(list(dict.fromkeys([track for track in seed_tracks if track])))
+        if seed_artists:
+            params["seed_artists"] = ",".join(list(dict.fromkeys([artist for artist in seed_artists if artist])))
+        if seed_genres:
+            params["seed_genres"] = ",".join(list(dict.fromkeys([genre for genre in seed_genres if genre])))
+        if tunable_params:
+            params.update({key: value for key, value in tunable_params.items() if value is not None})
+        return await self._request("GET", "/recommendations", params=params)
 
     async def get_playlist(self, playlist_id: str) -> Dict[str, Any]:
         params = {

--- a/backend/tests/test_recommendations.py
+++ b/backend/tests/test_recommendations.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence
+
+import numpy as np
+import pytest
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+
+pytest.importorskip("aiosqlite")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.core.config import Settings
+from app.db import models
+from app.db.base import Base
+from app.services.recommendations import (
+    _backfill_with_spotify,
+    _ensure_track_vector,
+    _load_track_with_artists,
+)
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_to_sqlite(element, compiler, **kw):  # pragma: no cover - SQLite shim
+    return "JSON"
+
+
+class _StubIndexService:
+    def __init__(self) -> None:
+        self.vectors: Dict[str, np.ndarray] = {}
+
+    async def ensure_loaded(self, session) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+    async def add_vectors(self, items: Iterable[tuple[str, np.ndarray]]) -> None:
+        for track_id, vector in items:
+            self.vectors[track_id] = vector
+
+    async def search(self, vector: np.ndarray, *, top_k: int) -> List[tuple[str, float]]:  # pragma: no cover - unused here
+        return []
+
+
+@dataclass(slots=True)
+class _StubSpotifyClient:
+    tracks: Dict[str, Dict[str, Any]]
+    features: Dict[str, Dict[str, Any]]
+    analysis: Dict[str, Dict[str, Any]]
+    artists: Dict[str, Dict[str, Any]]
+    recommendations: List[Dict[str, Any]]
+    last_request: Dict[str, Any] | None = None
+
+    async def get_track(self, track_id: str) -> Dict[str, Any]:
+        return self.tracks[track_id]
+
+    async def get_audio_features(self, track_id: str) -> Dict[str, Any]:
+        return self.features[track_id]
+
+    async def get_audio_analysis(self, track_id: str) -> Dict[str, Any]:
+        return self.analysis[track_id]
+
+    async def get_artists(self, artist_ids: Iterable[str]) -> List[Dict[str, Any]]:
+        return [self.artists[artist_id] for artist_id in artist_ids if artist_id in self.artists]
+
+    async def get_recommendations(
+        self,
+        *,
+        seed_tracks: Sequence[str] | None = None,
+        seed_artists: Sequence[str] | None = None,
+        seed_genres: Sequence[str] | None = None,
+        limit: int = 20,
+        tunable_params: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:  # pragma: no cover - parameters unused in stub
+        self.last_request = {
+            "seed_tracks": list(seed_tracks or []),
+            "seed_artists": list(seed_artists or []),
+            "seed_genres": list(seed_genres or []),
+            "limit": limit,
+            "tunable_params": dict(tunable_params or {}),
+        }
+        return {"tracks": list(self.recommendations)}
+
+
+async def _run_backfill_flow(tmp_path: Path) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with maker() as session:
+        seed_track_id = "seed-track"
+        recommendation_id = "rec-track"
+
+        seed_artist_id = "seed-artist"
+        rec_artist_id = "rec-artist"
+
+        stub_client = _StubSpotifyClient(
+            tracks={
+                seed_track_id: {
+                    "id": seed_track_id,
+                    "name": "Seed Song",
+                    "duration_ms": 180000,
+                    "explicit": False,
+                    "popularity": 40,
+                    "preview_url": None,
+                    "uri": "spotify:track:seed",
+                    "external_urls": {"spotify": "https://open.spotify.com/track/seed"},
+                    "album": {
+                        "id": "seed-album",
+                        "name": "Seed Album",
+                        "images": [{"url": "https://example.com/seed.jpg"}],
+                    },
+                    "artists": [
+                        {
+                            "id": seed_artist_id,
+                            "name": "Seed Artist",
+                        }
+                    ],
+                }
+            },
+            features={
+                seed_track_id: {
+                    "id": seed_track_id,
+                    "danceability": 0.62,
+                    "energy": 0.41,
+                    "speechiness": 0.05,
+                    "acousticness": 0.6,
+                    "instrumentalness": 0.0,
+                    "liveness": 0.12,
+                    "valence": 0.34,
+                    "tempo": 96.0,
+                    "mode": 1,
+                    "key": 5,
+                    "loudness": -8.0,
+                    "duration_ms": 180000,
+                },
+                recommendation_id: {
+                    "id": recommendation_id,
+                    "danceability": 0.64,
+                    "energy": 0.39,
+                    "speechiness": 0.04,
+                    "acousticness": 0.58,
+                    "instrumentalness": 0.0,
+                    "liveness": 0.15,
+                    "valence": 0.36,
+                    "tempo": 95.0,
+                    "mode": 1,
+                    "key": 5,
+                    "loudness": -9.0,
+                    "duration_ms": 182000,
+                },
+            },
+            analysis={
+                seed_track_id: {
+                    "track": {
+                        "tempo_confidence": 0.8,
+                        "time_signature": 4,
+                        "time_signature_confidence": 0.7,
+                        "key_confidence": 0.5,
+                    },
+                    "sections": [],
+                },
+                recommendation_id: {
+                    "track": {
+                        "tempo_confidence": 0.82,
+                        "time_signature": 4,
+                        "time_signature_confidence": 0.68,
+                        "key_confidence": 0.45,
+                    },
+                    "sections": [],
+                },
+            },
+            artists={
+                seed_artist_id: {
+                    "id": seed_artist_id,
+                    "name": "Seed Artist",
+                    "genres": ["viet r&b"],
+                },
+                rec_artist_id: {
+                    "id": rec_artist_id,
+                    "name": "Rec Artist",
+                    "genres": ["viet r&b", "asian r&b"],
+                },
+            },
+            recommendations=[
+                {
+                    "id": recommendation_id,
+                    "name": "Recommended Song",
+                    "duration_ms": 182000,
+                    "explicit": False,
+                    "popularity": 45,
+                    "preview_url": None,
+                    "uri": "spotify:track:rec",
+                    "external_urls": {"spotify": "https://open.spotify.com/track/rec"},
+                    "album": {
+                        "id": "rec-album",
+                        "name": "Rec Album",
+                        "images": [{"url": "https://example.com/rec.jpg"}],
+                    },
+                    "artists": [
+                        {
+                            "id": rec_artist_id,
+                            "name": "Rec Artist",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        settings = Settings(
+            faiss_index_path=tmp_path / "index.faiss",
+            faiss_meta_path=tmp_path / "index.json",
+            dsp_preview_timeout=0,
+        )
+        index_service = _StubIndexService()
+
+        seed_track, seed_vector, seed_features, _ = await _ensure_track_vector(
+            session,
+            stub_client,
+            index_service,
+            settings,
+            track_payload=await stub_client.get_track(seed_track_id),
+        )
+
+        seed_track_loaded = await _load_track_with_artists(session, seed_track.id)
+        assert seed_track_loaded is not None
+
+        recommendations = await _backfill_with_spotify(
+            session,
+            stub_client,
+            index_service,
+            settings,
+            seed_track=seed_track_loaded,
+            seed_vector=seed_vector,
+            seed_features=seed_features,
+            seed_genres={"viet r&b"},
+            existing=[],
+            limit=3,
+        )
+
+        assert any(item.track_id == recommendation_id for item in recommendations)
+
+        ingested_track = await session.get(models.Track, recommendation_id)
+        assert ingested_track is not None
+        assert {artist.id for artist in ingested_track.artists} == {rec_artist_id}
+
+    await engine.dispose()
+
+    return stub_client
+
+
+def test_spotify_backfill_ingests_unseen_tracks(tmp_path: Path) -> None:
+    stub_client = asyncio.run(_run_backfill_flow(tmp_path))
+    assert stub_client.last_request is not None
+    params = stub_client.last_request["tunable_params"]
+    assert pytest.approx(params["target_tempo"], rel=0.0, abs=0.01) == 96.0
+    assert params["min_tempo"] < params["target_tempo"] < params["max_tempo"]
+    assert pytest.approx(params["target_danceability"], rel=0.0, abs=0.001) == 0.62
+    assert params["min_danceability"] < params["target_danceability"] < params["max_danceability"]

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -49,11 +49,15 @@ export type SpotifyProfile = {
   email?: string;
 };
 
-export async function requestRecommendations(url: string): Promise<RecommendationResponse> {
+export async function requestRecommendations(url: string, limit?: number): Promise<RecommendationResponse> {
+  const payload: { url: string; limit?: number } = { url };
+  if (typeof limit === "number") {
+    payload.limit = limit;
+  }
   const res = await fetch("/api/recommend", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url }),
+    body: JSON.stringify(payload),
   });
   const data = await res.json();
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- route track recommendations entirely through Spotify's recommendation API instead of the FAISS index results
- extend the Spotify backfill helper to support extra seed artists/tracks and exclusion lists for richer playlist-driven seeding
- generate playlist recommendations via Spotify using aggregated playlist features while skipping tracks already present in the playlist

## Testing
- PYTHONDONTWRITEBYTECODE=1 pytest
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db2714e9208320adf82ec91de0a351